### PR TITLE
Rely on `solc` executable available on the PATH by default

### DIFF
--- a/solc.js
+++ b/solc.js
@@ -3,7 +3,7 @@ const path = require('path')
 const sh = require('./sh-sync')
 
 const DEFAULT_ROOT = './contracts'
-const DEFAULT_SOLC = '/usr/local/bin/solc'
+const DEFAULT_SOLC = 'solc'
 
 /**
  * Make solidity compiler for `root` base path with contracts.
@@ -14,7 +14,7 @@ const DEFAULT_SOLC = '/usr/local/bin/solc'
  *    const { abi, bin } = solc('Foo.sol')
  *
  * @param {string} .root = DEFAULT_ROOT ('./contracts') Contracts' root directory.
- * @param {string} .solc = DEFAULT_SOLC ('/usr/local/bin/solc') Solidity compiler executable path.
+ * @param {string} .solc = DEFAULT_SOLC ('solc') Solidity compiler should be on your PATH.
  * @return {function} Compiler function.
  */
 function make({ root = DEFAULT_ROOT, solc = DEFAULT_SOLC } = {}) {


### PR DESCRIPTION
  * providing a custom path is difficult at the moment, because
    other library files `web3-require.js` make use of this `solc.js`

  * as it should be relatively easy to add the `solc` executable
    to the system path

  * it is also possible to introduce a non standard ENV variable
    for the path to `solc`, but modifying the system PATH should
    be just as easy, and more standard