### PR TITLE
Fixing incorrect ambiguous check.

### DIFF
--- a/bytecode-link.js
+++ b/bytecode-link.js
@@ -33,7 +33,11 @@ function bytecodeLink(bytecode, links = {}) {
     }
   }
 
-  return keys(links).reduce((r, k) => r.replace(k, hex0xToHex(links[k])), bytecode)
+  return keys(links).reduce((r, k) =>
+    k.endsWith('___') ?
+      r.split(k).join(hex0xToHex(links[k])) :
+      r.replace(k, hex0xToHex(links[k]))
+  , bytecode)
 }
 
 module.exports = bytecodeLink

--- a/web3-require.js
+++ b/web3-require.js
@@ -6,7 +6,7 @@ const bytecodePlaceholders = require('./bytecode-placeholders')
 
 function throwOnAmbiguousPlaceholders(bytecode) {
   const ps = bytecodePlaceholders(bytecode)
-  const xs = uniq(map(ps.filter(_1 => _1.ambiguous), 'name'))
+  const xs = uniq(map(ps.filter(_1 => _1.ambiguous && !_1.name.endsWith('___')), 'name'))
   if (xs.length) {
     throw new Error(`Ambiguous placeholders ${xs.join(', ')}.`)
   }


### PR DESCRIPTION
It seems that bytecode allows for multiple occurrences of the same
placeholder and it's valid. We still want to protect ourselves for cases
where ambiguity occurs. This patch handles multiple occurrences of
placeholders which end with `___`, ie. they look like non ambiguous.

This is not ideal because it won't handle correctly names that happen
to have `_` character in the filename at 35th character.

This can be fixed further to handle this case, we could extract those
checks to helpers like `isSafePlaceholder(...)` which checks if 35th
char is different than `_` and allow replace-all on those links and
throw `Can't decide if placeholder is ambiguous.` if it's not and there
are multiple occurrences.