### PR TITLE
Add option to specify solc version and pull from docker

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -47,6 +47,10 @@ To deploy contract from shell you can use something like:
 
     cobalt-deploy -g 5000000 -f 0xfa9c654833f3e977b0f7c07c60bb69b656a47af7 -s HelloWorld.sol
 
+To compile with a solc docker container, specify a solc version:
+
+    cobalt-deploy -g 5000000 -f 0xfa9c654833f3e977b0f7c07c60bb69b656a47af7 -s HelloWorld.sol --solc-version=0.4.21
+
 ### Example jest test
 
 `test/foo.test.js`

--- a/bin/cobalt-compile.js
+++ b/bin/cobalt-compile.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+
+const program = require('commander')
+const pkg = require('../package.json')
+const makeWeb3 = require('../web3')
+
+program
+  .version(pkg.version)
+  .option('-r, --root [root]', 'Contract\'s root directory.', './contracts')
+  .option('-s, --sol <sol>', 'Solidity file.')
+  .option('--solc-version <version>', 'Solidity compiler version.')
+  .parse(process.argv)
+
+// Solidity file is required.
+if (!program.sol) {
+  console.log('Please provide solidity file via -s, --sol argument, ie. "-s Foo.sol".')
+  process.exit(-1)
+}
+
+const { root, sol, solcVersion } = program
+const { web3 } = makeWeb3({ root, solcVersion })
+
+web3.require(sol)
+
+const compiled = getCompiledContracts()
+console.log(JSON.stringify(compiled, null, 2))
+
+function getCompiledContracts() {
+  const output = {}
+  for (const [ name, ctr ] of Object.entries(web3.ctr)) {
+    const abi = JSON.stringify(ctr.options.jsonInterface)
+    const bin = ctr.options.data
+    output[name] = { abi, bin }
+  }
+  return output
+}

--- a/bin/cobalt-deploy.js
+++ b/bin/cobalt-deploy.js
@@ -25,6 +25,7 @@ function jsonParse(value) {
 program
   .version(pkg.version)
   .option('-p, --provider [provider]', 'Set provider.', 'http://localhost:8545')
+  .option('--solc-version <version>', 'Solidity compiler version. Uses solc on PATH if not provided.')
   .option('-r, --root [root]', 'Contract\'s root directory.', './contracts')
   .option('-s, --sol <sol>', 'Solidity file.')
   .option('-c, --contract [contract]', 'Contract name, defaults to solidity file without extension.')
@@ -52,8 +53,8 @@ if (!isHex0x(program.from)) {
 }
 
 const provider = makeProvider(program.provider)
-const { root, sol, args, from, gas, link: links } = program
-const { web3 } = makeWeb3({ provider, root })
+const { root, sol, solcVersion, args, from, gas, link: links } = program
+const { web3 } = makeWeb3({ provider, root, solcVersion })
 
 web3.require(sol)
 

--- a/solc.js
+++ b/solc.js
@@ -16,13 +16,18 @@ const DEFAULT_SOLC = process.env.SOLC || 'solc'
  *
  * @param {string} .root = DEFAULT_ROOT ('./contracts') Contracts' root directory.
  * @param {string} .solc = DEFAULT_SOLC ('solc') Solidity compiler should be on your PATH.
+ * @param {string} .solcVersion Solidity docker image tag to use. Overrides solc option.
  * @return {function} Compiler function.
  */
-function make({ root = DEFAULT_ROOT, solc = DEFAULT_SOLC, allowPaths } = {}) {
+function make({ root = DEFAULT_ROOT, solc = DEFAULT_SOLC, allowPaths, solcVersion } = {}) {
 
   const allowPathsParam = allowPaths ?
     `--allow-paths ${allowPaths}` :
     ''
+
+  if (solcVersion) {
+    solc = `docker run -v $(pwd):/solidity ethereum/solc:${solcVersion}`
+  }
 
   function compile(name) {
     const { stdout, stderr } = sh(`cd ${root} && ${solc} ${allowPathsParam} --combined-json abi,bin ${name}`)

--- a/web3-require.js
+++ b/web3-require.js
@@ -36,17 +36,17 @@ function throwOnAmbiguousPlaceholders(bytecode) {
  * @param {solc} .solc
  * @returns {object} an ethereum contract
  */
-function make({ root, solc, allowPaths }) {
+function make({ root, solc, allowPaths, solcVersion }) {
 
   // When `root` is defined, construct `solc`.
   if (root) {
     assert(!solc, 'Expected solc to be nil.')
-    solc = require('./solc')({ root, allowPaths })
+    solc = require('./solc')({ root, allowPaths, solcVersion })
   }
 
   // Try to see if we can see `./contracts`.
   if (!solc && isDir('./contracts')) {
-    solc = require('./solc')({ root: './contracts', allowPaths })
+    solc = require('./solc')({ root: './contracts', allowPaths, solcVersion })
   }
 
   // At this point, we need to have `solc` defined.

--- a/web3.js
+++ b/web3.js
@@ -93,9 +93,10 @@ function makeWeb3(options = {}) {
   // Decorate with `require`.
   const root = get(options, 'root')
   const solc = get(options, 'solc')
+  const solcVersion = get(options, 'solcVersion')
   const allowPaths = get(options, 'allowPaths')
   assert(!web3.require, 'Can\'t overwrite web3.require.')
-  web3.require = makeWeb3Require({ root, solc, allowPaths })
+  web3.require = makeWeb3Require({ root, solc, solcVersion, allowPaths })
 
   // Decorate with `deploy`.
   assert(!web3.deploy, 'Can\'t overwrite web3.deploy.')


### PR DESCRIPTION
Hi,

I spent yesterday looking into an issue in my smart contract and it turned out to be a compatibility issue between parity and some solidity compiler versions. I was unable to interact with another deployed contract from my contract e.g. `tokenContract.transfer(receiver, 1)`, and was constantly getting "stuck" - no response or error from parity. BUT my cobalt tests in ganache works correctly. 

My setup:
- solidity 0.4.22, 0.4.23, 0.4.24
- parity 1.10.0, 1.7.9 and latest
- private PoA network, 3 parity nodes
- contract deployment using custom web3.deploy scripts

I basically tried many many different combinations of code / config / solditiy version / parity version, and finally got it to work in parity when I compiled my contract with solidity v0.4.21.

Learnings (especially important if you're doing contract casting/linking)
- it's probably best to downgrade to solidity 0.4.21 for now. (will submit an issue to solidity when i get time)
- if you're not using truffle, prefer to use `cobalt-deploy` or `cobalt-web3` to compile & deploy rather than writing your own custom script - this reduces the differences between your tests and real deployments. 

This PR add support to allow specifying a solc docker image version to compile contracts, so you can easily switch between different solc versions:

Examples:

Compile:
`./bin/cobalt-compile.js -s HelloWorld.sol --solc-version 0.4.21`

Compile & Deploy
`./bin/cobalt-deploy.js -s HelloWorld.sol -f 0x00ea169ce7e0992960d3bde6f5d539c955316432 --solc-version 0.4.21`

Hope this helps.