### PR TITLE
Add the ability to specify the parity host

### DIFF
--- a/test/web3.test.js
+++ b/test/web3.test.js
@@ -2,6 +2,7 @@
 process.on('warning', err => console.warn(err.stack))
 
 const { expect } = require('code')
+const Web3 = require('../web3')
 const { web3, accounts } = require('../web3')({ accounts: 10 })
 const isChecksumAddress = require('../is-checksum-address')
 
@@ -16,6 +17,29 @@ describe('web3', function () {
     expect(isChecksumAddress(helloWorld.options.address)).to.be.true
     const helloWorld2 = web3.at('HelloWorld', helloWorld.options.address)
     expect(await helloWorld2.methods.helloWorld().call()).to.equal('Hello world!')
+  })
+
+  describe('provider', function () {
+    it('can use parity as a provider', () => {
+      // eslint-disable-next-line
+      const web3 = Web3({provider: 'parity'})
+
+      expect(web3.provider.constructor.name).to.equal('HttpProvider')
+      expect(web3.provider.host).to.equal('http://localhost:8545')
+    })
+
+    it('can set the url for the parity provider, and it can be a websocket', () => {
+      // eslint-disable-next-line
+      const web3 = Web3({provider: 'parity', host: 'ws://myhost:8546' })
+
+      expect(web3.provider.constructor.name).to.equal('WebsocketProvider')
+    })
+
+    it('throws an error if the parity host is invalid', () => {
+      // eslint-disable-next-line
+      expect(() => {Web3({provider: 'parity', host: 'wXs://myhost' })})
+        .to.throw(Error)
+    })
   })
 
   describe('link', function () {

--- a/test/web3.test.js
+++ b/test/web3.test.js
@@ -22,7 +22,7 @@ describe('web3', function () {
   describe('provider', function () {
     it('can use parity as a provider', () => {
       // eslint-disable-next-line
-      const web3 = Web3({provider: 'parity'})
+      const web3 = Web3({ provider: 'parity'})
 
       expect(web3.provider.constructor.name).to.equal('HttpProvider')
       expect(web3.provider.host).to.equal('http://localhost:8545')
@@ -30,15 +30,23 @@ describe('web3', function () {
 
     it('can set the url for the parity provider, and it can be a websocket', () => {
       // eslint-disable-next-line
-      const web3 = Web3({provider: 'parity', host: 'ws://myhost:8546' })
+      const web3 = Web3({ provider: 'parity', host: 'ws://myhost:8546' })
 
       expect(web3.provider.constructor.name).to.equal('WebsocketProvider')
     })
 
     it('throws an error if the parity host is invalid', () => {
       // eslint-disable-next-line
-      expect(() => {Web3({provider: 'parity', host: 'wXs://myhost' })})
+      expect(() => {Web3({ provider: 'parity', host: 'wXs://myhost' })})
         .to.throw(Error)
+    })
+
+    it('use the default ipc provider when the host starts with ipc', () => {
+      // eslint-disable-next-line
+      const web3 = Web3({ provider: 'parity', host: 'ipc:///somepath' })
+
+      expect(web3.provider.constructor.name).to.equal('IpcProvider')
+      expect(web3.provider.path).to.equal('ipc:///somepath')
     })
   })
 

--- a/test/web3.test.js
+++ b/test/web3.test.js
@@ -20,33 +20,26 @@ describe('web3', function () {
   })
 
   describe('provider', function () {
-    it('can use parity as a provider', () => {
+    it('can autodetect the provider when passed a string', () => {
       // eslint-disable-next-line
-      const web3 = Web3({ provider: 'parity'})
-
+      let web3 = Web3({ provider: 'http://localhost:8545'})
       expect(web3.provider.constructor.name).to.equal('HttpProvider')
-      expect(web3.provider.host).to.equal('http://localhost:8545')
-    })
 
-    it('can set the url for the parity provider, and it can be a websocket', () => {
+
       // eslint-disable-next-line
-      const web3 = Web3({ provider: 'parity', host: 'ws://myhost:8546' })
-
+      web3 = Web3({ provider: 'ws://myhost:8546' })
       expect(web3.provider.constructor.name).to.equal('WebsocketProvider')
-    })
 
-    it('throws an error if the parity host is invalid', () => {
+
       // eslint-disable-next-line
-      expect(() => {Web3({ provider: 'parity', host: 'wXs://myhost' })})
-        .to.throw(Error)
-    })
-
-    it('use the default ipc provider when the host starts with ipc', () => {
-      // eslint-disable-next-line
-      const web3 = Web3({ provider: 'parity', host: 'ipc:///somepath' })
-
+      web3 = Web3({ provider: 'ipc:///somepath' })
       expect(web3.provider.constructor.name).to.equal('IpcProvider')
-      expect(web3.provider.path).to.equal('ipc:///somepath')
+    })
+
+    it('throws an error if the provider is invalid', () => {
+      // eslint-disable-next-line
+      expect(() => {Web3({ provider: 'wXs://myhost' })})
+        .to.throw(Error)
     })
   })
 

--- a/web3.js
+++ b/web3.js
@@ -1,6 +1,5 @@
 
-// const net = require('net')
-// const { join } = require('path')
+const net = require('net')
 const assert = require('assert')
 const Web3 = require('web3')
 const ganache = require('ganache-core')
@@ -24,9 +23,12 @@ const providers = {
 
   parity({ host = DEFAULT_PARITY_HOST } = {}) {
     let provider
-    if (host.startsWith('http')) {
+
+    if (host.startsWith('ipc://')) {
+      provider = new Web3.providers.IpcProvider(host, net)
+    } else if (host.match(/^https?:\/\//)) {
       provider = new Web3.providers.HttpProvider(host)
-    } else if (host.startsWith('ws')) {
+    } else if (host.match(/^wss?:\/\//)) {
       provider = new Web3.providers.WebsocketProvider(host)
     } else {
       throw new Error('Invalid host url for provider: ' + host)

--- a/web3.js
+++ b/web3.js
@@ -1,6 +1,6 @@
 
 // const net = require('net')
-const { join } = require('path')
+// const { join } = require('path')
 const assert = require('assert')
 const Web3 = require('web3')
 const ganache = require('ganache-core')
@@ -14,21 +14,25 @@ const DEFAULT_PROVIDER = 'ganache'
 const DEFAULT_ACCOUNTS = 1000
 const DEFAULT_GAS_LIMIT = 50000000
 const DEFAULT_CHAIN_ID = 0x11
-const DEFAULT_IPC = join(process.env.HOME, '.local', 'share', 'io.parity.ethereum', 'jsonrpc.ipc')
 const DEFAULT_LOGGER = {
   log() {}
 }
 
+const DEFAULT_PARITY_HOST = 'http://localhost:8545'
+
 const providers = {
 
-  // TODO: Not complete/tested.
-  parity({ ipc = DEFAULT_IPC, accounts: n = DEFAULT_ACCOUNTS } = {}) {
-    console.log({ ipc })
-    const accounts = seedGanacheAccounts(n) // TODO: FIXME:
-    // const provider = new Web3.providers.IpcProvider(ipc, net)
-    // const provider = new Web3.providers.WebsocketProvider('ws://localhost:8546')
-    const provider = new Web3.providers.HttpProvider('http://localhost:8545')
-    return { provider, accounts, close: null }
+  parity({ host = DEFAULT_PARITY_HOST } = {}) {
+    let provider
+    if (host.startsWith('http')) {
+      provider = new Web3.providers.HttpProvider(host)
+    } else if (host.startsWith('ws')) {
+      provider = new Web3.providers.WebsocketProvider(host)
+    } else {
+      throw new Error('Invalid host url for provider: ' + host)
+    }
+
+    return { provider, accounts: [], close: null }
   },
 
   ganache({ accounts: n = DEFAULT_ACCOUNTS, chainId = DEFAULT_CHAIN_ID, gasLimit = DEFAULT_GAS_LIMIT, logger = DEFAULT_LOGGER, blocktime } = {}) {


### PR DESCRIPTION
Wrote this PR so I could use cobalt as a full-blown deployer programmatically.